### PR TITLE
fix

### DIFF
--- a/lib/vintage_net_wizard/backend_server.ex
+++ b/lib/vintage_net_wizard/backend_server.ex
@@ -405,10 +405,12 @@ defmodule VintageNetWizard.BackendServer do
         _from,
         %State{backend: backend, backend_state: backend_state} = state
       ) do
-    access_points = backend.access_points(backend_state)
-    Logger.info("BACKEND_SERVER: Access points requested - Found #{length(access_points)} networks")
+    access_points_raw = backend.access_points(backend_state)
+    access_points = if is_map(access_points_raw), do: Map.values(access_points_raw), else: access_points_raw
+    count = length(access_points)
+    Logger.info("BACKEND_SERVER: Access points requested - Found #{count} networks")
 
-    if length(access_points) == 0 do
+    if count == 0 do
       Logger.warning("BACKEND_SERVER: No access points found - this may indicate scanning issues with hardware")
       Logger.info("BACKEND_SERVER: Triggering additional scan attempt")
       # Force a scan if no access points are found


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change in access-point retrieval logic; main risk is unintended behavior if a backend returns a non-list/non-map shape.
> 
> **Overview**
> Updates `BackendServer`’s `:access_points` handler to tolerate backends returning either a list or a map of access points by normalizing maps via `Map.values/1`.
> 
> It also reuses a computed `count` for logging and for the “no networks found” branch that triggers an additional `VintageNet.scan/1` attempt.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57c0611e4fd20999bdb72b740efaef569288b775. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->