### PR TITLE
timer

### DIFF
--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -5,8 +5,6 @@ defmodule VintageNetWizard do
 
   alias VintageNetWizard.{APMode, APTimer, BackendServer, Web.Endpoint}
 
-  require Logger
-
   @type stop_reason() :: :shutdown | :timeout
 
   @doc """
@@ -91,8 +89,6 @@ defmodule VintageNetWizard do
   """
   @spec stop_wizard(stop_reason()) :: :ok | {:error, String.t()}
   def stop_wizard(stop_reason \\ :shutdown) do
-    APTimer.cancel()
-
     BackendServer.stop_cameras()
 
     :ok = BackendServer.complete()

--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -3,7 +3,9 @@ defmodule VintageNetWizard do
   Documentation for VintageNetWizard.
   """
 
-  alias VintageNetWizard.{APMode, BackendServer, Web.Endpoint}
+  alias VintageNetWizard.{APMode, APTimer, BackendServer, Web.Endpoint}
+
+  require Logger
 
   @type stop_reason() :: :shutdown | :timeout
 
@@ -47,7 +49,10 @@ defmodule VintageNetWizard do
       _ ->
         APMode.into_ap_mode(ap_ifname)
         |> case do
-          :ok -> start_services(opts, ap_on)
+          :ok ->
+            result = start_services(opts, ap_on)
+            start_ap_timer(ap_ifname)
+            result
           error -> error
         end
     end
@@ -86,6 +91,7 @@ defmodule VintageNetWizard do
   """
   @spec stop_wizard(stop_reason()) :: :ok | {:error, String.t()}
   def stop_wizard(stop_reason \\ :shutdown) do
+    APTimer.cancel()
 
     BackendServer.stop_cameras()
 
@@ -133,4 +139,8 @@ defmodule VintageNetWizard do
     end
   end
 
+  defp start_ap_timer(ap_ifname) do
+    ap_timeout = Application.get_env(:vintage_net_wizard, :ap_timeout, 15)
+    APTimer.start_link({ap_timeout, ap_ifname})
+  end
 end

--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -48,9 +48,12 @@ defmodule VintageNetWizard do
         APMode.into_ap_mode(ap_ifname)
         |> case do
           :ok ->
-            result = start_services(opts, ap_on)
-            start_ap_timer(ap_ifname)
-            result
+            case start_services(opts, ap_on) do
+              :ok ->
+                start_ap_timer(ap_ifname)
+                :ok
+              error -> error
+            end
           error -> error
         end
     end

--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -141,6 +141,6 @@ defmodule VintageNetWizard do
 
   defp start_ap_timer(ap_ifname) do
     ap_timeout = Application.get_env(:vintage_net_wizard, :ap_timeout, 15)
-    APTimer.start_link({ap_timeout, ap_ifname})
+    DynamicSupervisor.start_child(Endpoint, {APTimer, {ap_timeout, ap_ifname}})
   end
 end

--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -45,16 +45,16 @@ defmodule VintageNetWizard do
       # Start only the wizard server (web/API), without putting the interface in AP mode.
       :server_only -> start_services(opts, ap_on)
       _ ->
-        APMode.into_ap_mode(ap_ifname)
-        |> case do
+        require Logger
+        case APMode.into_ap_mode(ap_ifname) do
           :ok ->
-            case start_services(opts, ap_on) do
-              :ok ->
-                start_ap_timer(ap_ifname)
-                :ok
-              error -> error
-            end
-          error -> error
+            result = start_services(opts, ap_on)
+            Logger.info("[VintageNetWizard] AP up, services=#{inspect(result)}, starting timer for #{ap_ifname}")
+            start_ap_timer(ap_ifname)
+            result
+          error ->
+            Logger.error("[VintageNetWizard] into_ap_mode failed: #{inspect(error)}")
+            error
         end
     end
   end

--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -140,6 +140,12 @@ defmodule VintageNetWizard do
 
   defp start_ap_timer(ap_ifname) do
     ap_timeout = Application.get_env(:vintage_net_wizard, :ap_timeout, 15)
-    DynamicSupervisor.start_child(Endpoint, {APTimer, {ap_timeout, ap_ifname}})
+
+    case DynamicSupervisor.start_child(Endpoint, {APTimer, {ap_timeout, ap_ifname}}) do
+      {:ok, _pid} -> :ok
+      {:error, reason} ->
+        require Logger
+        Logger.warning("[VintageNetWizard] Failed to start AP timer: #{inspect(reason)}")
+    end
   end
 end

--- a/lib/vintage_net_wizard/ap_timer.ex
+++ b/lib/vintage_net_wizard/ap_timer.ex
@@ -31,15 +31,6 @@ defmodule VintageNetWizard.APTimer do
     end
   end
 
-  @doc "Cancel the timer (AP was already stopped by other means)"
-  def cancel do
-    if pid = Process.whereis(__MODULE__) do
-      DynamicSupervisor.terminate_child(VintageNetWizard.Web.Endpoint, pid)
-    end
-
-    :ok
-  end
-
   @impl GenServer
   def init({:infinity, _ap_ifname}) do
     Logger.info("[APTimer] AP timeout disabled (infinity)")

--- a/lib/vintage_net_wizard/ap_timer.ex
+++ b/lib/vintage_net_wizard/ap_timer.ex
@@ -1,0 +1,89 @@
+defmodule VintageNetWizard.APTimer do
+  @moduledoc false
+
+  # Separate timer for AP mode auto-shutdown.
+  #
+  # The WatchDog controls the HTTP server lifetime (can be :infinity).
+  # This timer controls how long the AP stays up (defaults to 15 minutes).
+  #
+  # When the timer fires, the AP is taken down but the HTTP server keeps running
+  # (transitions to server_only mode).
+  #
+  # Configure via:
+  #   config :vintage_net_wizard, ap_timeout: 15     # minutes
+  #   config :vintage_net_wizard, ap_timeout: :infinity  # never auto-stop AP
+
+  use GenServer, restart: :transient
+
+  require Logger
+
+  @doc "Start the AP timer"
+  def start_link({timeout_minutes, ap_ifname}) do
+    GenServer.start_link(__MODULE__, {timeout_minutes, ap_ifname}, name: __MODULE__)
+  end
+
+  @doc "Reset the AP timer (e.g. on user activity)"
+  def pet do
+    if pid = Process.whereis(__MODULE__) do
+      GenServer.call(pid, :pet)
+    else
+      :ok
+    end
+  end
+
+  @doc "Cancel the timer (AP was already stopped by other means)"
+  def cancel do
+    if pid = Process.whereis(__MODULE__) do
+      GenServer.stop(pid, :normal)
+    end
+
+    :ok
+  end
+
+  @impl GenServer
+  def init({:infinity, _ap_ifname}) do
+    Logger.info("[APTimer] AP timeout disabled (infinity)")
+    {:ok, :infinity}
+  end
+
+  def init({timeout_minutes, ap_ifname}) when is_integer(timeout_minutes) and timeout_minutes > 0 do
+    timeout_ms = timeout_minutes * 60_000
+    Logger.info("[APTimer] AP will auto-stop in #{timeout_minutes} min")
+    ref = Process.send_after(self(), :ap_timeout, timeout_ms)
+    {:ok, %{timeout_ms: timeout_ms, ap_ifname: ap_ifname, timer_ref: ref}}
+  end
+
+  @impl GenServer
+  def handle_call(:pet, _from, :infinity) do
+    {:reply, :ok, :infinity}
+  end
+
+  def handle_call(:pet, _from, %{timeout_ms: timeout_ms} = state) do
+    Process.cancel_timer(state.timer_ref)
+    ref = Process.send_after(self(), :ap_timeout, timeout_ms)
+    {:reply, :ok, %{state | timer_ref: ref}}
+  end
+
+  @impl GenServer
+  def handle_info(:ap_timeout, %{ap_ifname: ap_ifname} = state) do
+    Logger.info("[APTimer] AP timeout reached — stopping AP mode on #{ap_ifname}")
+
+    # Restore wlan0 to its previous WiFi config (exit AP, keep server running)
+    config = VintageNet.get(["interface", ap_ifname, "config"])
+
+    networks =
+      case config do
+        %{vintage_net_wifi: %{networks: networks}} ->
+          Enum.reject(networks, &(Map.get(&1, :mode) == :ap))
+
+        _ ->
+          []
+      end
+
+    VintageNetWizard.APMode.exit_ap_mode(ap_ifname, networks)
+    {:stop, :normal, state}
+  end
+
+  @impl GenServer
+  def terminate(:normal, _), do: :ok
+end

--- a/lib/vintage_net_wizard/ap_timer.ex
+++ b/lib/vintage_net_wizard/ap_timer.ex
@@ -24,10 +24,14 @@ defmodule VintageNetWizard.APTimer do
 
   @doc "Reset the AP timer (e.g. on user activity)"
   def pet do
-    if pid = Process.whereis(__MODULE__) do
-      GenServer.call(pid, :pet)
-    else
-      :ok
+    case Process.whereis(__MODULE__) do
+      nil -> :ok
+      pid ->
+        try do
+          GenServer.call(pid, :pet)
+        catch
+          :exit, _ -> :ok
+        end
     end
   end
 

--- a/lib/vintage_net_wizard/ap_timer.ex
+++ b/lib/vintage_net_wizard/ap_timer.ex
@@ -69,15 +69,24 @@ defmodule VintageNetWizard.APTimer do
   def handle_info(:ap_timeout, %{ap_ifname: ap_ifname} = state) do
     Logger.info("[APTimer] AP timeout reached — stopping AP mode on #{ap_ifname}")
 
-    # Read the PERSISTED config (pre-AP WiFi networks), not the runtime AP config
-    config = VintageNet.get_configuration(ap_ifname)
+    # Read the PERSISTED config from disk (the pre-AP WiFi networks).
+    # AP mode is configured with persist: false, so disk still has the real WiFi config.
+    persistence = Application.get_env(:vintage_net, :persistence, VintageNet.Persistence.FlatFile)
 
     networks =
-      case get_in(config, [:vintage_net_wifi, :networks]) do
-        nil -> []
-        nets -> Enum.reject(nets, &(Map.get(&1, :mode) == :ap))
+      case persistence.load(ap_ifname) do
+        {:ok, config} ->
+          case get_in(config, [:vintage_net_wifi, :networks]) do
+            nil -> []
+            nets -> Enum.reject(nets, &(Map.get(&1, :mode) == :ap))
+          end
+
+        _ ->
+          Logger.warning("[APTimer] No persisted config for #{ap_ifname}, restoring with empty networks")
+          []
       end
 
+    Logger.info("[APTimer] Restoring #{length(networks)} WiFi network(s)")
     VintageNetWizard.APMode.exit_ap_mode(ap_ifname, networks)
     {:stop, :normal, state}
   end

--- a/lib/vintage_net_wizard/ap_timer.ex
+++ b/lib/vintage_net_wizard/ap_timer.ex
@@ -65,16 +65,13 @@ defmodule VintageNetWizard.APTimer do
   def handle_info(:ap_timeout, %{ap_ifname: ap_ifname} = state) do
     Logger.info("[APTimer] AP timeout reached — stopping AP mode on #{ap_ifname}")
 
-    # Restore wlan0 to its previous WiFi config (exit AP, keep server running)
-    config = VintageNet.get(["interface", ap_ifname, "config"])
+    # Read the PERSISTED config (pre-AP WiFi networks), not the runtime AP config
+    config = VintageNet.get_configuration(ap_ifname)
 
     networks =
-      case config do
-        %{vintage_net_wifi: %{networks: networks}} ->
-          Enum.reject(networks, &(Map.get(&1, :mode) == :ap))
-
-        _ ->
-          []
+      case get_in(config, [:vintage_net_wifi, :networks]) do
+        nil -> []
+        nets -> Enum.reject(nets, &(Map.get(&1, :mode) == :ap))
       end
 
     VintageNetWizard.APMode.exit_ap_mode(ap_ifname, networks)

--- a/lib/vintage_net_wizard/ap_timer.ex
+++ b/lib/vintage_net_wizard/ap_timer.ex
@@ -34,7 +34,7 @@ defmodule VintageNetWizard.APTimer do
   @doc "Cancel the timer (AP was already stopped by other means)"
   def cancel do
     if pid = Process.whereis(__MODULE__) do
-      GenServer.stop(pid, :normal)
+      DynamicSupervisor.terminate_child(VintageNetWizard.Web.Endpoint, pid)
     end
 
     :ok
@@ -59,7 +59,13 @@ defmodule VintageNetWizard.APTimer do
   end
 
   def handle_call(:pet, _from, %{timeout_ms: timeout_ms} = state) do
-    Process.cancel_timer(state.timer_ref)
+    Process.cancel_timer(state.timer_ref, info: false)
+    # Flush any stale :ap_timeout that fired before cancel
+    receive do
+      :ap_timeout -> :ok
+    after
+      0 -> :ok
+    end
     ref = Process.send_after(self(), :ap_timeout, timeout_ms)
     {:reply, :ok, %{state | timer_ref: ref}}
   end

--- a/lib/vintage_net_wizard/web/endpoint.ex
+++ b/lib/vintage_net_wizard/web/endpoint.ex
@@ -74,6 +74,7 @@ defmodule VintageNetWizard.Web.Endpoint do
     _ =
       get_children()
       |> stop_some_children()
+      |> handle_ap_timer()
       |> handle_watchdog(stop_reason)
       |> handle_callbacks()
 
@@ -92,6 +93,13 @@ defmodule VintageNetWizard.Web.Endpoint do
 
   # if the reason for stopping is a timeout then we don't try to stop
   # the WatchDog as it will stop itself.
+  defp handle_ap_timer(children) do
+    if children[APTimer] do
+      _ = DynamicSupervisor.terminate_child(__MODULE__, children[APTimer])
+    end
+    children
+  end
+
   defp handle_watchdog(children, :timeout), do: children
 
   defp handle_watchdog(children, _other) do

--- a/lib/vintage_net_wizard/web/endpoint.ex
+++ b/lib/vintage_net_wizard/web/endpoint.ex
@@ -5,6 +5,7 @@ defmodule VintageNetWizard.Web.Endpoint do
   use DynamicSupervisor
 
   alias VintageNetWizard.{
+    APTimer,
     Backend,
     BackendServer,
     Callbacks,
@@ -81,7 +82,7 @@ defmodule VintageNetWizard.Web.Endpoint do
 
   defp stop_some_children(children) do
     children
-    |> Map.drop([WatchDog, Callbacks])
+    |> Map.drop([WatchDog, APTimer, Callbacks])
     |> Enum.each(fn {_mod, child} ->
       :ok = DynamicSupervisor.terminate_child(__MODULE__, child)
     end)
@@ -115,7 +116,7 @@ defmodule VintageNetWizard.Web.Endpoint do
 
   @impl DynamicSupervisor
   def init(_) do
-    DynamicSupervisor.init(strategy: :one_for_one, max_children: 4)
+    DynamicSupervisor.init(strategy: :one_for_one, max_children: 5)
   end
 
   defp dispatch(opts) do

--- a/lib/vintage_net_wizard/web/plugs/activity.ex
+++ b/lib/vintage_net_wizard/web/plugs/activity.ex
@@ -2,7 +2,7 @@ defmodule VintageNetWizard.Plugs.Activity do
   @moduledoc false
 
   alias Plug.Conn
-  alias VintageNetWizard.WatchDog
+  alias VintageNetWizard.{APTimer, WatchDog}
 
   @typedoc """
   Options for the plug:
@@ -26,6 +26,7 @@ defmodule VintageNetWizard.Plugs.Activity do
       conn
     else
       :ok = WatchDog.pet()
+      APTimer.pet()
       conn
     end
   end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new AP auto-shutdown behavior that changes network state asynchronously and restores persisted WiFi config, so misconfiguration or timer bugs could unexpectedly drop AP connectivity.
> 
> **Overview**
> Adds a new `APTimer` GenServer to **auto-exit WiFi AP mode** after a configurable `:ap_timeout` (minutes or `:infinity`) while leaving the HTTP wizard server running.
> 
> `run_wizard/1` now starts this timer after successfully entering AP mode (with additional logging), the Activity plug resets the timer on user requests, and `Web.Endpoint.stop_server/1` explicitly terminates the timer and increases its supervisor `max_children` to accommodate the extra child.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b51b4568a1c10c18b3a06e2a41c3d6d6eb3e77f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->